### PR TITLE
Integrate amr parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,49 @@
 
 `python -m claim_detection.models --input TXT_FILES --patterns claim_detection/topics.json --out OUT_FILE`
 
+## Including AMR graphs
+
+In order to use AMR graphs to enhance the results, you will need to run
+an action-pointer model from IBM's Transition AMR Parser on the input files.
+
+1. Clone the repository and `cd` into it.
+2. Create a new conda environment for the parser (there are several
+   conflicting packages between this and the claims detection).
+3. Activate the new conda env and run `python -m pip install -e .`
+4. Run `bash tests/correclty_installed.sh` to confirm that the installation succeeded.
+5. For a basic test, run `bash tests/minimal_test.sh`
+6. You will also need the install the alignment tools with these steps:
+   1. In the `preprocess/` folder, git clone https://github.com/jflanigan/jamr.git
+   2. Make sure that your Java environment is Java 8.
+   3. Create the file `~/.sbt/repositories` (if it doesn't already exist)
+      and add these lines to it:
+      ```
+      [repositories]
+         maven-central: https://repo1.maven.org/maven2/
+      ```
+   4. In `jamr/build.sbt`, remove these lines:
+      * `import AssemblyKeys._`
+      * `assemblySettings`
+   5. In the same file, change the `scala-arm` version to 2.0 like so:
+      ```
+      libraryDependencies ++= Seq(
+          "com.jsuereth" %% "scala-arm" % "2.0",
+      ```
+   6. In `jamr/project/plugins.sbt`, do the following:
+      * Update the `sbt-assembly` version (--> 0.14.6)
+      * Update the `sbteclipse-plugin` version (--> 5.2.4)
+      * Remove the line that adds the `sbt-idea` plugin
+   7. Create the file `jamr/project/build.properties` and add an available sbt version to it, like so:
+      * `sbt.version=1.2.0`
+   8. Within the jamr root, run `./setup`
+   9. Still in jamr, run `. scripts/config.sh`
+   10. Follow the `# Kevin aligner` steps in `install_alignment_tools.sh`
+7. Either train your own model or obtain the data from someone on the project.
+8. Run the following:
+   ```
+   python -m amr_parsing.parse_files \
+       TRANSITION_AMR_PARSER_PATH TXT_FILES AMR_OUTPUT_DIR
+   ```
+9. To run the claims detection with the AMR output, run `claim_detection.models`
+   along with the argument `--amrs AMR_OUTPUT_DIR`
+

--- a/README.md
+++ b/README.md
@@ -2,23 +2,18 @@
 
 ## Installation
 
+### CDSE
+
 1. Clone repo
 2. Create virtual environment
 3. Run `bash setup.sh`
 
-## Usage
+### Transition AMR Parser
 
-`python -m claim_detection.models --input TXT_FILES --patterns claim_detection/topics.json --out OUT_FILE`
-
-## Including AMR graphs
-
-In order to use AMR graphs to enhance the results, you will need to run
-an action-pointer model from IBM's Transition AMR Parser on the input files.
-
-1. Clone the repository and `cd` into it.
+1. Clone the repository (with HTTPS, not SSH) at https://github.com/IBM/transition-amr-parser .
 2. Create a new conda environment for the parser (there are several
    conflicting packages between this and the claims detection).
-3. Activate the new conda env and run `python -m pip install -e .`
+3. Activate the new conda env, and in the parser root dir, and run `python -m pip install -e .`
 4. Run `bash tests/correclty_installed.sh` to confirm that the installation succeeded.
 5. For a basic test, run `bash tests/minimal_test.sh`
 6. You will also need the install the alignment tools with these steps:
@@ -47,12 +42,19 @@ an action-pointer model from IBM's Transition AMR Parser on the input files.
    8. Within the jamr root, run `./setup`
    9. Still in jamr, run `. scripts/config.sh`
    10. Follow the `# Kevin aligner` steps in `install_alignment_tools.sh`
-7. Either train your own model or obtain the data from someone on the project.
-8. Run the following:
-   ```
-   python -m amr_parsing.parse_files \
-       TRANSITION_AMR_PARSER_PATH TXT_FILES AMR_OUTPUT_DIR
-   ```
-9. To run the claims detection with the AMR output, run `claim_detection.models`
-   along with the argument `--amrs AMR_OUTPUT_DIR`
+7. Either train your own model (see instructions in the parser README)
+   or obtain the data from someone on the project.
 
+## Usage
+
+1. Create the AMR files
+   ```
+   conda activate <transition-amr-parser-env>
+   python -m amr_parsing.parse_files \
+       --amr_parser TRANSITION_AMR_PARSER_PATH --input TXT_FILES --out AMR_FILES
+   ```
+2. Claim detection:
+   ```
+   conda activate <cdse-covid-env>
+   python -m claim_detection.models --input AMR_FILES --patterns claim_detection/topics.json --out OUT_FILE
+   ```

--- a/amr_parsing/parse_files.py
+++ b/amr_parsing/parse_files.py
@@ -3,8 +3,8 @@ Takes the corpus files and creates AMR graphs for each sentence.
 
 You will need to run this in your transition-amr virtual environment.
 """
+import argparse
 from os import chdir, getcwd, makedirs
-import sys
 from pathlib import Path
 from typing import List
 
@@ -15,39 +15,44 @@ NLP = spacy.load("en_core_web_sm")
 TOKENIZER = NLP.tokenizer
 
 
-def main(args):
-    transition_amr_repo_path = args[1]
-    input_dir = Path(args[2])
-    output_dir = args[3]
+def main(arg_parser):
+    arg_parser.add_argument(
+        "--amr_parser",
+        help="Path to the installation of transition-amr-parser",
+        type=Path,
+    )
+    arg_parser.add_argument("--input", help="Input docs", type=Path)
+    arg_parser.add_argument("--out", help="AMR output dir", type=Path)
 
+    args = arg_parser.parse_args()
     cdse_path = getcwd()
 
     # We assume that the checkpoint is in this location within the repo
-    in_checkpoint = f"{transition_amr_repo_path}/DATA/AMR2.0/models" \
+    in_checkpoint = f"{args.amr_parser}/DATA/AMR2.0/models" \
                     "/exp_cofill_o8.3_act-states_RoBERTa-large-top24" \
                     "/_act-pos-grh_vmask1_shiftpos1_ptr-lay6-h1_grh-lay123-h2-allprev" \
                     "_1in1out_cam-layall-h2-abuf/ep120-seed42/checkpoint_best.pt"
 
     if not Path(in_checkpoint).exists():
         raise RuntimeError(f"Could not find checkpoint file {in_checkpoint}!")
-    if not input_dir.exists():
-        raise RuntimeError(f"Input directory {input_dir} could not be found!")
-    if not Path(output_dir).exists():
-        makedirs(output_dir)
+    if not args.input.exists():
+        raise RuntimeError(f"Input directory {args.input} could not be found!")
+    if not Path(args.out).exists():
+        makedirs(args.out)
 
-    chdir(transition_amr_repo_path)
+    chdir(args.amr_parser)
     amr_parser = AMRParser.from_checkpoint(in_checkpoint)
     chdir(cdse_path)
-    for input_file in input_dir.iterdir():
+    for input_file in args.input.iterdir():
         doc_sentences = tokenize_sentences(input_file)
         annotations = amr_parser.parse_sentences(doc_sentences)
 
-        output_file = f"{output_dir}/{input_file.stem}.amr"
+        output_file = f"{args.out}/{input_file.stem}.amr"
         with open(output_file, 'w+', encoding="utf-8") as outfile:
             # PENMAN notation is at index 0
             for anno_number, annotation in enumerate(annotations[0]):
-                # Append an id to each graph
-                # so that it can be loaded by amr-utils
+                # Append an id to each graph so that
+                # it can be loaded by amr-utils later
                 outfile.write(f"# ::id {input_file.stem}_{anno_number}\n")
                 outfile.writelines(''.join(annotation))
         print(f"AMR output saved to {Path(output_file).absolute()}")
@@ -64,4 +69,4 @@ def tokenize_sentences(corpus_file) -> List[List[str]]:
 
 
 if __name__ == "__main__":
-    main(sys.argv)
+    main(argparse.ArgumentParser())

--- a/amr_parsing/parse_files.py
+++ b/amr_parsing/parse_files.py
@@ -6,7 +6,7 @@ You will need to run this in your transition-amr virtual environment.
 import argparse
 from os import chdir, getcwd, makedirs
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 import spacy
 from transition_amr_parser.parse import AMRParser
@@ -44,8 +44,8 @@ def main(arg_parser):
     amr_parser = AMRParser.from_checkpoint(in_checkpoint)
     chdir(cdse_path)
     for input_file in args.input.iterdir():
-        doc_sentences = tokenize_sentences(input_file)
-        annotations = amr_parser.parse_sentences(doc_sentences)
+        doc_sentences, tokenized_sentences = tokenize_sentences(input_file)
+        annotations = amr_parser.parse_sentences(tokenized_sentences)
 
         output_file = f"{args.out}/{input_file.stem}.amr"
         with open(output_file, 'w+', encoding="utf-8") as outfile:
@@ -54,18 +54,19 @@ def main(arg_parser):
                 # Append an id to each graph so that
                 # it can be loaded by amr-utils later
                 outfile.write(f"# ::id {input_file.stem}_{anno_number}\n")
+                outfile.write(f"# ::snt {doc_sentences[anno_number]}")
                 outfile.writelines(''.join(annotation))
         print(f"AMR output saved to {Path(output_file).absolute()}")
 
 
-def tokenize_sentences(corpus_file) -> List[List[str]]:
+def tokenize_sentences(corpus_file) -> Tuple[List[str], List[List[str]]]:
     tokenized_sentences = []
     with open(corpus_file, 'r') as infile:
         input_sentences = infile.readlines()
     for sentence in input_sentences:
         tokens = TOKENIZER(sentence)
         tokenized_sentences.append([token.text for token in tokens])
-    return tokenized_sentences
+    return input_sentences, tokenized_sentences
 
 
 if __name__ == "__main__":

--- a/amr_parsing/parse_files.py
+++ b/amr_parsing/parse_files.py
@@ -1,0 +1,67 @@
+"""
+Takes the corpus files and creates AMR graphs for each sentence.
+
+You will need to run this in your transition-amr virtual environment.
+"""
+from os import chdir, getcwd, makedirs
+import sys
+from pathlib import Path
+from typing import List
+
+import spacy
+from transition_amr_parser.parse import AMRParser
+
+NLP = spacy.load("en_core_web_sm")
+TOKENIZER = NLP.tokenizer
+
+
+def main(args):
+    transition_amr_repo_path = args[1]
+    input_dir = Path(args[2])
+    output_dir = args[3]
+
+    cdse_path = getcwd()
+
+    # We assume that the checkpoint is in this location within the repo
+    in_checkpoint = f"{transition_amr_repo_path}/DATA/AMR2.0/models" \
+                    "/exp_cofill_o8.3_act-states_RoBERTa-large-top24" \
+                    "/_act-pos-grh_vmask1_shiftpos1_ptr-lay6-h1_grh-lay123-h2-allprev" \
+                    "_1in1out_cam-layall-h2-abuf/ep120-seed42/checkpoint_best.pt"
+
+    if not Path(in_checkpoint).exists():
+        raise RuntimeError(f"Could not find checkpoint file {in_checkpoint}!")
+    if not input_dir.exists():
+        raise RuntimeError(f"Input directory {input_dir} could not be found!")
+    if not Path(output_dir).exists():
+        makedirs(output_dir)
+
+    chdir(transition_amr_repo_path)
+    amr_parser = AMRParser.from_checkpoint(in_checkpoint)
+    chdir(cdse_path)
+    for input_file in input_dir.iterdir():
+        doc_sentences = tokenize_sentences(input_file)
+        annotations = amr_parser.parse_sentences(doc_sentences)
+
+        output_file = f"{output_dir}/{input_file.stem}.amr"
+        with open(output_file, 'w+', encoding="utf-8") as outfile:
+            # PENMAN notation is at index 0
+            for anno_number, annotation in enumerate(annotations[0]):
+                # Append an id to each graph
+                # so that it can be loaded by amr-utils
+                outfile.write(f"# ::id {input_file.stem}_{anno_number}\n")
+                outfile.writelines(''.join(annotation))
+        print(f"AMR output saved to {Path(output_file).absolute()}")
+
+
+def tokenize_sentences(corpus_file) -> List[List[str]]:
+    tokenized_sentences = []
+    with open(corpus_file, 'r') as infile:
+        input_sentences = infile.readlines()
+    for sentence in input_sentences:
+        tokens = TOKENIZER(sentence)
+        tokenized_sentences.append([token.text for token in tokens])
+    return tokenized_sentences
+
+
+if __name__ == "__main__":
+    main(sys.argv)

--- a/dataset.py
+++ b/dataset.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from spacy.tokens import Doc
-from typing import Sequence
+from typing import Sequence, Dict
 
 
 class AIDADataset:
@@ -30,3 +30,15 @@ class AIDADataset:
                 parsed_english = self.nlp(doc_text)
                 all_docs.append(parsed_english)
         return all_docs
+
+    def _batch_convert_to_spacy_with_amr(
+            self, corpus: Path, amrs: Path
+    ) -> Dict[Doc, Path]:
+        docs_to_amrs: Dict[Doc, Path] = {}
+        for _file in corpus.glob("*.txt"):
+            with open(_file, "r") as handle:
+                doc_text = handle.read()
+                parsed_english = self.nlp(doc_text)
+                amr_file = Path(f"{amrs}/{_file.stem}.amr")
+                docs_to_amrs[parsed_english] = amr_file
+        return docs_to_amrs

--- a/dataset.py
+++ b/dataset.py
@@ -41,7 +41,7 @@ class AIDADataset:
         for _file in amr_files.glob("*.amr"):
             amrs = AMR_READER.load(_file, remove_wiki=True)
             sentences = [
-                " ".join(graph.tokens)[:-7]
+                graph.metadata["snt"]
                 for graph in amrs
             ]
             doc_text = " ".join(sentences)

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,7 @@ flake8==3.9.2
 fsspec==2021.7.0
 ftfy==6.0.3
 future==0.18.2
+git+git://github.com/ablodge/amr-utils@be5534d#egg=amr-utils
 gitdb==4.0.7
 GitPython==3.1.18
 google-api-core==1.31.1
@@ -118,6 +119,7 @@ pathtools==0.1.2
 pathy==0.6.0
 patternfork-nosql==3.6
 pdfminer.six==20201018
+penman==1.2.1
 pexpect==4.8.0
 pickleshare==0.7.5
 Pillow==8.3.1


### PR DESCRIPTION
This PR serves to present a concept of how the AMR graphs might be used to improve the claims detection output.

1. Adds a step to create AMR graphs from corpus text
2. Changes `models.py` to take the AMR graphs as input
3. Defines and implements the function `_identify_claimer` such that it uses the AMR input