### PR TITLE
Add general method for finding select x-variables

### DIFF
--- a/cdse_covid/pegasus_pipeline/claim_pipeline.py
+++ b/cdse_covid/pegasus_pipeline/claim_pipeline.py
@@ -106,7 +106,8 @@ def main(params: Parameters):
         f"""
         --input {claim_detection_output.value} \
         --output {amr_output_dir} \
-        --amr-parser-model {amr_params.existing_directory("model_path")}
+        --amr-parser-model {amr_params.existing_directory("model_path")} \
+        --domain {amr_params.string("domain")}
         """,
         override_conda_config=CondaConfiguration(
             conda_base_path=params.existing_directory("conda_base_path"),

--- a/cdse_covid/semantic_extraction/amr_extraction_utils.py
+++ b/cdse_covid/semantic_extraction/amr_extraction_utils.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Dict
 from amr_utils.alignments import AMR_Alignment
 from amr_utils.amr import AMR
 
+PROPBANK_PATTERN = r"[a-z]*-[0-9]{2}"
 
 def create_amr_dict(amr: AMR) -> Dict[str, Dict[str, List[str]]]:
     # {"parent": {"role1": ["child1"], "role2": ["child2", "child3"]}, ...}
@@ -53,9 +54,8 @@ def get_full_description(
     <ARG1-of> <consist-of> <mod>* <focus_node> <op1> <ARG1>
     """
     descr_strings = []
-    propbank_pattern = r"[a-z]*-[0-9]{2}"
     focus_string = nodes_to_strings[focus_node]
-    if re.match(propbank_pattern, nodes_to_labels[focus_node]):
+    if re.match(PROPBANK_PATTERN, nodes_to_labels[focus_node]):
         node_args = amr_dict[focus_node]
         for arg_role, arg_node_list in node_args.items():
             # Only check ARG1 to avoid grabbing extraneous arguments
@@ -176,9 +176,7 @@ def identify_x_variable(
         for parent, role, child in amr.edges:
             child_label = nodes_to_labels.get(child)
             # Not all locations get the :location role label
-            if role == ":location" or role == ":source" or any(
-                    child_label == place_type for place_type in place_types
-            ):
+            if role == ":location" or role == ":source" or child_label in place_types:
                 location_name = get_full_name_value(
                     amr_dict, nodes_to_source_strings, child
                 )
@@ -333,7 +331,10 @@ def identify_x_variable(
 
 
 def identify_x_variable_general(
-        amr: AMR, alignments: List[AMR_Alignment], claim_ents: Dict[str, str]
+        amr: AMR,
+        alignments: List[AMR_Alignment],
+        claim_ents: Dict[str, str],
+        claim_pos: Dict[str, str]
 ) -> Optional[str]:
     """
     Use the AMR graph of the claim to identify the X variable given the claim text
@@ -341,7 +342,6 @@ def identify_x_variable_general(
     An alternative to `identify_x_variable` that doesn't rely on the templates
     of our COVID-19 domain
     """
-    location_entity_labels = {"GPE", "FAC" "LOC"}
     place_types = {"city", "state", "country", "continent"}
     amr_dict = create_amr_dict(amr)
     nodes_to_labels = amr.nodes
@@ -349,22 +349,45 @@ def identify_x_variable_general(
 
     # First use entity labels as clues for what the X-variable is
     for entity, label in claim_ents.items():
-        if label in location_entity_labels:
-            # For claims with a FAC/GPE/LOC, try to find the full argument
+        if label == "NORP":
+            # A nationality may hint at the variable
             for parent, role, child in amr.edges:
+                parent_label = nodes_to_labels.get(parent)
                 child_label = nodes_to_labels.get(child)
-                # Not all locations get the :location role label
-                if role == ":location" or role == ":source" or any(
-                        child_label == place_type for place_type in place_types
-                ):
-                    location_name = get_full_name_value(
-                        amr_dict, nodes_to_source_strings, child
+                # Check if it's a government organization
+                if parent_label == "government-organization":
+                    add_gov_token = True if "government" in amr.tokens else False
+                    # try up to two steps down
+                    full_name = None
+                    if child_label in place_types:
+                        full_name = get_full_name_value(
+                            amr_dict, nodes_to_source_strings, child
+                        )
+                    else:
+                        gov_args = amr_dict[child]
+                        for values in gov_args.values():
+                            for value in values:
+                                if nodes_to_labels[value] in place_types:
+                                    full_name = get_full_name_value(
+                                        amr_dict, nodes_to_source_strings, value
+                                    )
+                    if full_name and add_gov_token:
+                        return full_name + " government"
+                    return full_name
+                if parent_label in place_types:
+                    return get_full_description(
+                        amr_dict, nodes_to_labels, nodes_to_source_strings, parent
                     )
-                    return location_name if location_name else get_full_description(
-                        amr_dict, nodes_to_labels, nodes_to_source_strings, child
-                    )
-        # if label == "NORP":
-        #     # A nationality may hint at the variable
+                if child_label in place_types:
+                    # If the nationality is a mod, check the parent
+                    if claim_pos.get(nodes_to_source_strings[child]) == "ADJ":
+                        return get_full_description(
+                            amr_dict, nodes_to_labels, nodes_to_source_strings, parent
+                        )
+                    else:
+                        return get_full_description(
+                            amr_dict, nodes_to_labels, nodes_to_source_strings, child
+                        )
         if label == "PERSON" or label == "ORG":
             # If a PERSON/ORG is detected, get the full name
             for parent, role, child in amr.edges:
@@ -375,9 +398,20 @@ def identify_x_variable_general(
                     )
                     return person_name if person_name else child_label
 
-    # If there is a date-entity in the AMR graph, that may be the X-variable
-    for node, node_label in nodes_to_labels.items():
-        if node_label == "date-entity":
+    # Next, simply look for a location
+    for parent, role, child in amr.edges:
+        parent_label = nodes_to_labels.get(parent)
+        child_label = nodes_to_labels.get(child)
+        # Not all locations get the :location role label
+        if role == ":location" or role == ":source" or child_label in place_types:
+            location_name = get_full_name_value(
+                amr_dict, nodes_to_source_strings, child
+            )
+            return location_name if location_name else get_full_description(
+                amr_dict, nodes_to_labels, nodes_to_source_strings, child
+            )
+        # If there is a date-entity in the AMR graph, that may be the X-variable
+        if parent_label == "date-entity":
             return get_full_description(
-                amr_dict, nodes_to_labels, nodes_to_source_strings, node
+                amr_dict, nodes_to_labels, nodes_to_source_strings, parent
             )

--- a/cdse_covid/semantic_extraction/amr_extraction_utils.py
+++ b/cdse_covid/semantic_extraction/amr_extraction_utils.py
@@ -8,6 +8,7 @@ from amr_utils.amr import AMR
 
 PROPBANK_PATTERN = r"[a-z]*-[0-9]{2}"
 
+
 def create_amr_dict(amr: AMR) -> Dict[str, Dict[str, List[str]]]:
     # {"parent": {"role1": ["child1"], "role2": ["child2", "child3"]}, ...}
     amr_dict = defaultdict(lambda: defaultdict(list))
@@ -159,7 +160,7 @@ def fix_alignment(alignment: AMR_Alignment) -> AMR_Alignment:
     return alignment
 
 
-def identify_x_variable(
+def identify_x_variable_covid(
         amr: AMR, alignments: List[AMR_Alignment], claim_template: str
 ) -> Optional[str]:
     """
@@ -330,7 +331,7 @@ def identify_x_variable(
                 )
 
 
-def identify_x_variable_general(
+def identify_x_variable(
         amr: AMR,
         alignments: List[AMR_Alignment],
         claim_ents: Dict[str, str],
@@ -339,7 +340,7 @@ def identify_x_variable_general(
     """
     Use the AMR graph of the claim to identify the X variable given the claim text
 
-    An alternative to `identify_x_variable` that doesn't rely on the templates
+    An alternative to `identify_x_variable_covid` that doesn't rely on the templates
     of our COVID-19 domain
     """
     place_types = {"city", "state", "country", "continent"}

--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -19,7 +19,7 @@ from amr_utils.amr_readers import AMR_Reader, Matedata_Parser
 from cdse_covid.claim_detection.run_claim_detection import ClaimDataset
 from cdse_covid.semantic_extraction.models import AMRLabel
 from cdse_covid.semantic_extraction.claimer_utils import identify_claimer
-from cdse_covid.semantic_extraction.amr_extraction_utils import identify_x_variable
+from cdse_covid.semantic_extraction.amr_extraction_utils import identify_x_variable, identify_x_variable_general
 
 
 def tokenize_sentence(text, spacy_tokenizer) -> List[str]:
@@ -68,8 +68,14 @@ def main(input_dir, output, *, spacy_model, parser_path):
         claimr, claim_alignments = AMR_Reader._parse_amr_from_metadata(
             claim_metadata["tok"], claim_graph_metadata
         )
-        possible_x_variable = identify_x_variable(
-            claimr, claim_alignments, claim.claim_template
+        claim_ents = {
+            ent.text: ent.label_ for ent in spacy_model(claim.claim_text).ents
+        }
+        # possible_x_variable = identify_x_variable(
+        #     claimr, claim_alignments, claim.claim_template
+        # )
+        possible_x_variable = identify_x_variable_general(
+            claimr, claim_alignments, claim_ents
         )
         if possible_x_variable:
             claim.x_variable = possible_x_variable

--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -19,7 +19,9 @@ from amr_utils.amr_readers import AMR_Reader, Matedata_Parser
 from cdse_covid.claim_detection.run_claim_detection import ClaimDataset
 from cdse_covid.semantic_extraction.models import AMRLabel
 from cdse_covid.semantic_extraction.claimer_utils import identify_claimer
-from cdse_covid.semantic_extraction.amr_extraction_utils import identify_x_variable, identify_x_variable_general
+from cdse_covid.semantic_extraction.amr_extraction_utils import identify_x_variable_covid, identify_x_variable
+
+COVID_DOMAIN = "covid"
 
 
 def tokenize_sentence(text, spacy_tokenizer) -> List[str]:
@@ -28,7 +30,7 @@ def tokenize_sentence(text, spacy_tokenizer) -> List[str]:
     return tokenized_sentence
 
 
-def main(input_dir, output, *, spacy_model, parser_path):
+def main(input_dir, output, *, spacy_model, parser_path, domain):
 
     cdse_path = getcwd()
 
@@ -68,18 +70,20 @@ def main(input_dir, output, *, spacy_model, parser_path):
         claimr, claim_alignments = AMR_Reader._parse_amr_from_metadata(
             claim_metadata["tok"], claim_graph_metadata
         )
-        claim_ents = {
-            ent.text: ent.label_ for ent in spacy_model(claim.claim_text).ents
-        }
-        claim_pos = {
-            token.text: token.pos_ for token in spacy_model(claim.claim_text).doc
-        }
-        # possible_x_variable = identify_x_variable(
-        #     claimr, claim_alignments, claim.claim_template
-        # )
-        possible_x_variable = identify_x_variable_general(
-            claimr, claim_alignments, claim_ents, claim_pos
-        )
+        if domain == COVID_DOMAIN:
+            possible_x_variable = identify_x_variable_covid(
+                claimr, claim_alignments, claim.claim_template
+            )
+        else:
+            claim_ents = {
+                ent.text: ent.label_ for ent in spacy_model(claim.claim_text).ents
+            }
+            claim_pos = {
+                token.text: token.pos_ for token in spacy_model(claim.claim_text).doc
+            }
+            possible_x_variable = identify_x_variable(
+                claimr, claim_alignments, claim_ents, claim_pos
+            )
         if possible_x_variable:
             claim.x_variable = possible_x_variable
 
@@ -96,9 +100,18 @@ if __name__ == "__main__":
     parser.add_argument("--input", help="Input docs", type=Path)
     parser.add_argument("--output", help="AMR output dir", type=Path)
     parser.add_argument("--amr-parser-model", type=Path)
+    parser.add_argument(
+        "--domain", help="`covid` or `general`", type=str, default="general"
+    )
 
     args = parser.parse_args()
 
     model = spacy.load("en_core_web_sm")
 
-    main(args.input, args.output, spacy_model=model, parser_path=args.amr_parser_model)
+    main(
+        args.input,
+        args.output,
+        spacy_model=model,
+        parser_path=args.amr_parser_model,
+        domain=args.domain
+    )

--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -71,11 +71,14 @@ def main(input_dir, output, *, spacy_model, parser_path):
         claim_ents = {
             ent.text: ent.label_ for ent in spacy_model(claim.claim_text).ents
         }
+        claim_pos = {
+            token.text: token.pos_ for token in spacy_model(claim.claim_text).doc
+        }
         # possible_x_variable = identify_x_variable(
         #     claimr, claim_alignments, claim.claim_template
         # )
         possible_x_variable = identify_x_variable_general(
-            claimr, claim_alignments, claim_ents
+            claimr, claim_alignments, claim_ents, claim_pos
         )
         if possible_x_variable:
             claim.x_variable = possible_x_variable

--- a/params/claims_pipeline.params
+++ b/params/claims_pipeline.params
@@ -16,6 +16,7 @@ amr:
     python_file_all: "%project_root%/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py"
     python_file: "%project_root%/cdse_covid/semantic_extraction/run_amr_parsing.py"
     model_path: /Users/jcummings/Desktop/projects/GAIA/transition-amr-parser
+    domain: "covid"
 
 srl:
     python_file: "%project_root%/cdse_covid/semantic_extraction/run_srl.py"


### PR DESCRIPTION
Closes #22 
The new `identify_x_variable_general` currently only relies on argument/entity roles and POS to determine x-variables.