### PR TITLE
Add sentence token limit for amr parsing, other small mods

### DIFF
--- a/cdse_covid/pegasus_pipeline/claim_pipeline.py
+++ b/cdse_covid/pegasus_pipeline/claim_pipeline.py
@@ -56,17 +56,22 @@ def main(params: Parameters):
     amr_all_loc = base_locator / "amr_all"
     amr_all_python_file = amr_params.existing_file("python_file_all")
     amr_all_output_dir = directory_for(amr_all_loc) / "documents"
+    amr_max_tokens = amr_params.integer("max_tokens", default=50)
     if params.string("site") == "saga":
-        larger_resource = SlurmResourceRequest(memory=MemoryAmount.parse("8G"))
+        larger_resource = SlurmResourceRequest(
+            memory=MemoryAmount.parse("8G"),
+            num_gpus=1
+        )
     else:
         larger_resource = None
     amr_all_job = run_python_on_args(
         amr_all_loc,
         amr_all_python_file,
         f"""
-        --corpus {input_corpus_dir}
-        --output {amr_all_output_dir}
-        --amr-parser-model {amr_params.existing_directory("model_path")}
+        --corpus {input_corpus_dir} \
+        --output {amr_all_output_dir} \
+        --amr-parser-model {amr_params.existing_directory("model_path")} \
+        --max-tokens {amr_max_tokens}
         """,
         override_conda_config=CondaConfiguration(
             conda_base_path=params.existing_directory("conda_base_path"),
@@ -111,7 +116,8 @@ def main(params: Parameters):
         --input {claim_detection_output.value} \
         --output {amr_output_dir} \
         --amr-parser-model {amr_params.existing_directory("model_path")} \
-        --domain {amr_params.string("domain")}
+        --max_tokens {amr_max_tokens} \
+        --domain {amr_params.string("domain", default="general")}
         """,
         override_conda_config=CondaConfiguration(
             conda_base_path=params.existing_directory("conda_base_path"),

--- a/cdse_covid/pegasus_pipeline/claim_pipeline.py
+++ b/cdse_covid/pegasus_pipeline/claim_pipeline.py
@@ -116,7 +116,7 @@ def main(params: Parameters):
         --input {claim_detection_output.value} \
         --output {amr_output_dir} \
         --amr-parser-model {amr_params.existing_directory("model_path")} \
-        --max_tokens {amr_max_tokens} \
+        --max-tokens {amr_max_tokens} \
         --domain {amr_params.string("domain", default="general")}
         """,
         override_conda_config=CondaConfiguration(

--- a/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
+++ b/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
@@ -15,8 +15,6 @@ from amr_utils.amr import AMR
 from amr_utils.amr_readers import AMR_Reader
 from transition_amr_parser.parse import AMRParser  # pylint: disable=import-error
 
-from cdse_covid.semantic_extraction.run_amr_parsing import tokenize_sentence
-
 ALIGNMENTS_TYPE = Dict[Union[List[str], str], Union[List[AMR_Alignment], list]]
 AMR_READER = AMR_Reader()
 STOP_PUNCTUATION = "!?.:;—,"
@@ -31,14 +29,20 @@ def tokenize_sentences(
         with open(corpus_file, 'r') as infile:
             input_sentences = infile.readlines()
         for sentence in input_sentences:
-            tokenized_sentence = tokenize_sentence(sentence, spacy_tokenizer)
+            tokenized_sentence = tokenize_sentence(
+                sentence, spacy_tokenizer, max_tokens
+            )
             # Filter for blank lines
             if 1 <= len(tokenized_sentence):
-                tokenized_sentences.append(
-                    refine_sentence(tokenized_sentence, max_tokens)
-                )
+                tokenized_sentences.append(tokenized_sentence)
                 doc_sentences_to_include.append(sentence)
     return doc_sentences_to_include, tokenized_sentences
+
+
+def tokenize_sentence(text, spacy_tokenizer, max_tokens) -> List[str]:
+    tokens = spacy_tokenizer(text.strip())
+    tokenized_sentence = [token.text for token in tokens]
+    return refine_sentence(tokenized_sentence, max_tokens)
 
 
 def refine_sentence(tokenized_sentence: List[str], max_tokens: int) -> List[str]:

--- a/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
+++ b/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
@@ -4,6 +4,7 @@ Takes the corpus files and creates AMR graphs for each sentence.
 You will need to run this in your transition-amr virtual environment.
 """
 import argparse
+import string
 from os import getcwd, makedirs, chdir
 from pathlib import Path
 from typing import List, Tuple, Union, Dict, Optional
@@ -30,11 +31,31 @@ def tokenize_sentences(
             input_sentences = infile.readlines()
         for sentence in input_sentences:
             tokenized_sentence = tokenize_sentence(sentence, spacy_tokenizer)
-            # Blank line & long sentence filter
-            if 1 <= len(tokenized_sentence) <= max_tokens:
+            # Filter for blank lines and sentences with many or weird tokens
+            if (
+                    1 <= len(tokenized_sentence) <= max_tokens
+                    and not has_weird_token(tokenized_sentence)
+            ):
+
                 tokenized_sentences.append(tokenized_sentence)
                 doc_sentences_to_include.append(sentence)
     return doc_sentences_to_include, tokenized_sentences
+
+
+def has_weird_token(
+        tokenized_sentence: List[str]
+) -> bool:
+    """
+    Filter out sentences with tokens containing letters and punctuation;
+    we believe this has something to do with weird parsing errors
+    """
+    for token in tokenized_sentence:
+        if (
+                any(punc in token for punc in string.punctuation) and
+                any(letter in token for letter in string.ascii_letters)
+        ):
+            return True
+    return False
 
 
 def load_amr_from_text_file(

--- a/params/claims_pipeline.params
+++ b/params/claims_pipeline.params
@@ -16,6 +16,7 @@ amr:
     python_file_all: "%project_root%/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py"
     python_file: "%project_root%/cdse_covid/semantic_extraction/run_amr_parsing.py"
     model_path: /Users/jcummings/Desktop/projects/GAIA/transition-amr-parser
+    max_tokens: 50
     domain: "covid"
 
 srl:


### PR DESCRIPTION
* Adds method for removing clauses after a cutoff point (default = 50)
* Fixes "bad" tokens in sentence before AMR parsing
* Prevents the AMR parser from running if there are no qualified sentences to parse
* Other minor bug fixes/improvements

Waiting to test this on SAGA