### PR TITLE
Use Google docstring convention, remove backslashes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ lint:
 	pylint $(PYTHON_FILES)
 
 docstyle:
-	pydocstyle $(PYTHON_FILES)
+	pydocstyle --convention=google $(PYTHON_FILES)
 
 mypy:
 	mypy $(PYTHON_FILES)

--- a/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
+++ b/cdse_covid/pegasus_pipeline/run_amr_parsing_all.py
@@ -43,11 +43,13 @@ def tokenize_sentence(text: str, spacy_tokenizer: Any, max_tokens: int) -> List[
 
 
 def refine_sentence(tokenized_sentence: List[str], max_tokens: int) -> List[str]:
-    """If a sentence exceeds the token limit, split the sentence into clauses \
-    based on punctuation and keep all tokens within a clause that passes \
+    """Refine a tokenized sentence.
+
+    If a sentence exceeds the token limit, split the sentence into clauses
+    based on punctuation and keep all tokens within a clause that passes
     the threshold.
 
-    Additionally, take any token with a format like \
+    Additionally, take any token with a format like
     "X)Y" and separate it ("X", ")", "Y") to avoid parser errors.
     """
     refined_sentence = []
@@ -62,7 +64,7 @@ def refine_sentence(tokenized_sentence: List[str], max_tokens: int) -> List[str]
 def load_amr_from_text_file(amr_file: Path, output_alignments: bool = False) -> Any:
     """Reads a document of AMR graphs and returns an AMR graph.
 
-    If `output_alignments` is True, it will also return \
+    If `output_alignments` is True, it will also return
     the alignment data of that graph.
     """
     if output_alignments:

--- a/cdse_covid/semantic_extraction/models/amr.py
+++ b/cdse_covid/semantic_extraction/models/amr.py
@@ -29,11 +29,10 @@ class AMRModel(object):
 
     @classmethod
     def from_folder(cls, folder: Path) -> "AMRModel":
-        """Return an AMRModel object using an AMRParser created from the model data \
-        saved in your copy of transition-amr-parser.
+        """Return an AMRModel object using an AMRParser created from the model data saved in your copy of transition-amr-parser.
 
-        For some reason, the program isn't able to detect the model data \
-        if the working directory is not the amr-parser root, even if you provide \
+        For some reason, the program isn't able to detect the model data
+        if the working directory is not the amr-parser root, even if you provide
         an absolute path, hence why we change working dirs in this method.
         """
         cdse_path = getcwd()

--- a/cdse_covid/semantic_extraction/utils/amr_extraction_utils.py
+++ b/cdse_covid/semantic_extraction/utils/amr_extraction_utils.py
@@ -330,7 +330,7 @@ def identify_x_variable(
     of our COVID-19 domain.
     """
     place_types = {"city", "state", "country", "continent"}
-    amr_dict = amr.edge_MutableMapping()
+    amr_dict = amr.edge_mapping()
     nodes_to_labels = amr.nodes
     nodes_to_source_strings = create_node_to_token_dict(amr, alignments)
 

--- a/cdse_covid/semantic_extraction/utils/claimer_utils.py
+++ b/cdse_covid/semantic_extraction/utils/claimer_utils.py
@@ -35,9 +35,9 @@ def identify_claimer(
     """Identify the claimer of the span.
 
     Finding claim node:
-        1. Try to match the claim tokens to a token in the AMR graph \
+        1. Try to match the claim tokens to a token in the AMR graph
             then work up to find the 'statement' node
-        2. If 1 fails, find the first 'statement' node in the graph and \
+        2. If 1 fails, find the first 'statement' node in the graph and
             select that as the claim node
 
     Finding claimer:


### PR DESCRIPTION
Closes #34 

[This](http://www.pydocstyle.org/en/6.1.1/error_codes.html#default-conventions) says that the default convention that PyDocStyle uses is `pep257`. Changing it to `google` ignores the check for D400, and we're encouraged to use that style at ISI anyway.

Note that it still runs D415, in which the first line needs to end with a period, question mark, or exclamation point. In these changes, I either put the full summary on one line or added a brief first line and moved the rest down.