### PR TITLE
Make all non-entity qnodes type qnodes

### DIFF
--- a/cdse_covid/pegasus_pipeline/ingesters/aida_txt_ingester.py
+++ b/cdse_covid/pegasus_pipeline/ingesters/aida_txt_ingester.py
@@ -12,7 +12,7 @@ def load_aida_txt_docs(docs_to_load: Path, output_dir: Path, *, spacy_model: Lan
     for txt_file in docs_to_load.glob("*.txt"):
         with open(txt_file, "r", encoding="utf-8") as handle:
             doc_text = handle.read()
-            doc_id = txt_file.stem
+            doc_id = txt_file.stem.strip(".rsd")
             doc = spacy_model(doc_text)
             doc.to_disk(f"{output_dir / doc_id}.spacy")
 

--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -70,7 +70,7 @@ def main(
                 device,
             )
             if best_qnode:
-                claim.claimer_identity_qnode = best_qnode
+                claim.claimer_type_qnode = best_qnode
 
         claim_amr = amr_parser.amr_parse_sentences([tokenized_claim])
 

--- a/cdse_covid/semantic_extraction/run_entity_merging.py
+++ b/cdse_covid/semantic_extraction/run_entity_merging.py
@@ -170,7 +170,8 @@ def main(
                 all_kes, claim.x_variable.span, include_contains
             )
             if x_variable_mention:
-                # The x-variable is an entity, so make its qnode the identity qnode
+                # The x-variable is an entity, so make its qnode the identity qnode.
+                # The _type_qnode will be replaced later, so we don't bother removing it.
                 claim.x_variable_identity_qnode = claim.x_variable_type_qnode
                 claim.x_variable.entity = x_variable_mention.parent_entity
                 entity_freebase = claim.x_variable.entity.freebase_link

--- a/cdse_covid/semantic_extraction/run_wikidata_linking.py
+++ b/cdse_covid/semantic_extraction/run_wikidata_linking.py
@@ -188,8 +188,10 @@ def create_wikidata_qnodes(link: Any, mention: Mention, claim: Claim) -> Optiona
             else:
                 first_option = all_options[0]
                 text = first_option["label"][0] if first_option["label"] else None
-                qnode = first_option["qnode"][0] if first_option["qnode"] else None
-                description = first_option["description"][0] if first_option["description"] else None
+                qnode = first_option["qnode"] if first_option["qnode"] else None
+                description = (
+                    first_option["description"][0] if first_option["description"] else None
+                )
     else:
         text = link["options"][0]["rawName"]
         qnode = link["options"][0]["qnode"]

--- a/cdse_covid/semantic_extraction/run_wikidata_linking.py
+++ b/cdse_covid/semantic_extraction/run_wikidata_linking.py
@@ -159,7 +159,7 @@ def main(
                     device,
                 )
                 if best_qnode:
-                    claim.x_variable_identity_qnode = best_qnode
+                    claim.x_variable_type_qnode = best_qnode
         else:
             logging.warning(
                 "Could not load AMR or alignments for claim sentence '%s'",
@@ -174,15 +174,22 @@ def main(
 def create_wikidata_qnodes(link: Any, mention: Mention, claim: Claim) -> Optional[WikidataQnode]:
     """Create WikiData Qnodes from links."""
     if len(link["options"]) < 1:
-        all_options = link["all_options"]
-        if len(all_options) < 1:
-            logging.warning("No WikiData links found for '%s'.", link["query"])
-            return None
-        else:
-            first_option = all_options[0]
-            text = first_option["label"][0] if first_option["label"] else None
+        other_options = link["other_options"]
+        if len(other_options) > 1:
+            first_option = other_options[0]
+            text = first_option["rawName"][0] if first_option["rawName"] else None
             qnode = first_option["qnode"][0] if first_option["qnode"] else None
-            description = first_option["description"][0] if first_option["description"] else None
+            description = first_option["definition"][0] if first_option["definition"] else None
+        else:
+            all_options = link["all_options"]
+            if len(all_options) < 1:
+                logging.warning("No WikiData links found for '%s'.", link["query"])
+                return None
+            else:
+                first_option = all_options[0]
+                text = first_option["label"][0] if first_option["label"] else None
+                qnode = first_option["qnode"][0] if first_option["qnode"] else None
+                description = first_option["description"][0] if first_option["description"] else None
     else:
         text = link["options"][0]["rawName"]
         qnode = link["options"][0]["qnode"]

--- a/wikidata_linker/get_claim_semantics.py
+++ b/wikidata_linker/get_claim_semantics.py
@@ -85,16 +85,15 @@ def get_all_labeled_args(
             if arg_node:
                 framenet_arg = get_framenet_arg_role(arg[1])
                 if qnode_args.get(framenet_arg):
-                    role = qnode_args[framenet_arg]["text_role"]
                     node_label = amr.nodes[arg_node]
                     token_of_node = node_labels_to_tokens.get(arg_node)
                     if not token_of_node:
-                        labeled_args[role] = node_label.rsplit("-", 1)[0]
+                        labeled_args[framenet_arg] = node_label.rsplit("-", 1)[0]
                     elif any(token_of_node.endswith(f" {stop_word}") for stop_word in STOP_WORDS):
                         # Sometimes the extracted token or part of it is irrelevant
-                        labeled_args[role] = token_of_node.rsplit(" ")[0]
+                        labeled_args[framenet_arg] = token_of_node.rsplit(" ")[0]
                     else:
-                        labeled_args[role] = token_of_node
+                        labeled_args[framenet_arg] = token_of_node
     return labeled_args
 
 
@@ -193,15 +192,18 @@ def get_claim_semantics(
         labeled_args = get_all_labeled_args(amr_sentence, amr_alignments, node, best_qnode["args"])
         wd = get_wikidata_for_labeled_args(amr_sentence, claim, labeled_args, linking_model, device)
 
-    claim_event = ClaimEvent(
-        text=best_qnode.get("name"),
-        doc_id=claim.doc_id,
-        description=best_qnode.get("definition"),
-        from_query=best_qnode.get("pb"),
-        qnode_id=best_qnode.get("qnode"),
-    )
-    claim_args = {k: {"type": w} for k, w in wd.items()}
-    return ClaimSemantics(event=claim_event, args=claim_args)
+    if best_qnode:
+        claim_event = ClaimEvent(
+            text=best_qnode.get("name"),
+            doc_id=claim.doc_id,
+            description=best_qnode.get("definition"),
+            from_query=best_qnode.get("pb"),
+            qnode_id=best_qnode.get("qnode"),
+        )
+
+        claim_args = {k: {"type": w} for k, w in wd.items()}
+        return ClaimSemantics(event=claim_event, args=claim_args)
+    return None
 
 
 def determine_best_qnode(

--- a/wikidata_linker/get_claim_semantics.py
+++ b/wikidata_linker/get_claim_semantics.py
@@ -200,7 +200,7 @@ def get_claim_semantics(
         from_query=best_qnode.get("pb"),
         qnode_id=best_qnode.get("qnode"),
     )
-    claim_args = {k: {"identity": w} for k, w in wd.items()}
+    claim_args = {k: {"type": w} for k, w in wd.items()}
     return ClaimSemantics(event=claim_event, args=claim_args)
 
 


### PR DESCRIPTION
Closes #95 
Closes #89 

This better differentiates identity/type qnodes under the following assumptions:
1. All mentions with a parent entity have qnodes that should be identity qnodes.
2. All other mention qnodes are type qnodes.

A few other fixes are included:
* Strips `.rsd` from doc IDs
* Uses basic framenet argument roles in claim semantics (A0, A1, etc.)
* Claim semantics will be `null` if no event qnode is found.