### PR TITLE
Select mention qnode based on kgtk score

### DIFF
--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -53,7 +53,6 @@ def main(
             claim.claim_sentence, spacy_model.tokenizer, max_tokens
         )
         sentence_amr = amr_parser.amr_parse_sentences([tokenized_sentence])
-        print(sentence_amr.graph.graph_string())
         tokenized_claim = tokenize_sentence(claim.claim_text, spacy_model.tokenizer, max_tokens)
         possible_claimer = identify_claimer(
             claim, tokenized_claim, sentence_amr.graph, sentence_amr.alignments

--- a/cdse_covid/semantic_extraction/run_amr_parsing.py
+++ b/cdse_covid/semantic_extraction/run_amr_parsing.py
@@ -53,6 +53,7 @@ def main(
             claim.claim_sentence, spacy_model.tokenizer, max_tokens
         )
         sentence_amr = amr_parser.amr_parse_sentences([tokenized_sentence])
+        print(sentence_amr.graph.graph_string())
         tokenized_claim = tokenize_sentence(claim.claim_text, spacy_model.tokenizer, max_tokens)
         possible_claimer = identify_claimer(
             claim, tokenized_claim, sentence_amr.graph, sentence_amr.alignments

--- a/cdse_covid/semantic_extraction/run_entity_merging.py
+++ b/cdse_covid/semantic_extraction/run_entity_merging.py
@@ -107,7 +107,6 @@ def create_wikidata_qnode_from_id(mention: Mention, qnode_id: str) -> Optional[W
             "rawName": kgtk_result["label"][0],
             "definition": kgtk_result["description"][0] if kgtk_result["description"] else "",
         }
-    print(f"Qnode info for {qnode_id}:\n{selected_qnode}")
 
     if selected_qnode:
         return WikidataQnode(

--- a/cdse_covid/semantic_extraction/run_wikidata_linking.py
+++ b/cdse_covid/semantic_extraction/run_wikidata_linking.py
@@ -2,126 +2,15 @@
 import argparse
 import logging
 from pathlib import Path
-import re
-from typing import Any, List, Optional
 
-from amr_utils.alignments import AMR_Alignment
-from amr_utils.amr import AMR
 import spacy
 from spacy.language import Language
 import torch
 
-from cdse_covid.claim_detection.claim import Claim
 from cdse_covid.claim_detection.run_claim_detection import ClaimDataset
-from cdse_covid.semantic_extraction.mentions import Mention, WikidataQnode
-from cdse_covid.semantic_extraction.utils.amr_extraction_utils import PROPBANK_PATTERN
-from wikidata_linker.get_claim_semantics import STOP_WORDS, determine_best_qnode, load_tables
+from wikidata_linker.get_claim_semantics import get_best_qnode_for_mention_text
 from wikidata_linker.linker import WikidataLinkingClassifier
-from wikidata_linker.wikidata_linking import (
-    CPU,
-    REFVAR,
-    VERB,
-    disambiguate_refvar_kgtk,
-    disambiguate_verb_kgtk,
-)
-
-
-def find_links(
-    span: str,
-    query: str,
-    query_type: str,
-    linking_model: WikidataLinkingClassifier,
-    device: str = CPU,
-) -> Any:
-    """Find WikiData links for a set of tokens.
-
-    Assumes the query is a refvar by default.
-    """
-    if query_type == VERB:
-        return disambiguate_verb_kgtk(query, linking_model, k=1, device=device)
-    else:
-        return disambiguate_refvar_kgtk(query, linking_model, span, k=1, device=device)
-
-
-def get_best_qnode_for_mention_text(
-    mention: Mention,
-    claim: Claim,
-    amr: AMR,
-    alignments: List[AMR_Alignment],
-    spacy_model: Language,
-    linking_model: WikidataLinkingClassifier,
-    device: str,
-) -> Optional[WikidataQnode]:
-    """Return the best WikidataQnode for a string within the claim sentence.
-
-    First, if the string comes from a propbank frame, try a DWD lookup.
-    Otherwise, run KGTK.
-    """
-    mention_text = mention.text
-    if not mention_text:
-        return None
-    # Make both tables
-    pbs_to_qnodes_master, pbs_to_qnodes_overlay = load_tables()
-
-    # Find the label associated with the last token of the variable text
-    # (any tokens before it are likely modifiers)
-    variable_node_label = None
-    claim_variable_tokens = [
-        mention_token
-        for mention_token in mention_text.split(" ")
-        if mention_token not in STOP_WORDS
-    ]
-    claim_variable_tokens.reverse()
-
-    # Locate the AMR node label associated with the mention text
-    for node in amr.nodes:
-        token_list_for_node = amr.get_tokens_from_node(node, alignments)
-        # Try to match the last token since it is most likely to point to the correct node
-        if claim_variable_tokens[0] in token_list_for_node:
-            variable_node_label = amr.nodes[node].strip('"')
-
-    if not variable_node_label:
-        logging.warning(
-            "DWD lookup: could not find AMR node corresponding with XVariable/Claimer '%s'",
-            mention_text,
-        )
-
-    elif re.match(PROPBANK_PATTERN, variable_node_label):
-        best_qnode = determine_best_qnode(
-            variable_node_label,
-            pbs_to_qnodes_overlay,
-            pbs_to_qnodes_master,
-            amr,
-            spacy_model,
-            linking_model,
-            check_mappings_only=True,
-        )
-        if best_qnode:
-            return WikidataQnode(
-                text=best_qnode.get("name"),
-                mention_id=mention.mention_id,
-                doc_id=claim.doc_id,
-                span=mention.span,
-                description=best_qnode.get("definition"),
-                from_query=best_qnode.get("pb"),
-                qnode_id=best_qnode.get("qnode"),
-            )
-    # If no Qnode was found, try KGTK
-    query_list: List[Optional[str]] = [mention.text, variable_node_label, *claim_variable_tokens]
-    for query in list(filter(None, query_list)):
-        claim_variable_links = find_links(
-            claim.claim_sentence, query, REFVAR, linking_model, device
-        )
-        claim_event_links = find_links(claim.claim_sentence, query, VERB, linking_model, device)
-        # Combine the results
-        all_claim_links = claim_variable_links
-        all_claim_links["options"].extend(claim_event_links["options"])
-        all_claim_links["other_options"].extend(claim_event_links["other_options"])
-        all_claim_links["all_options"].extend(claim_event_links["all_options"])
-        top_link = create_wikidata_qnodes(all_claim_links, mention, claim)
-        if top_link:
-            return top_link
-    return None
+from wikidata_linker.wikidata_linking import CPU
 
 
 def main(
@@ -169,43 +58,6 @@ def main(
     claim_dataset.save_to_dir(output)
 
     logging.info("Saved claims with Wikidata to %s", output)
-
-
-def create_wikidata_qnodes(link: Any, mention: Mention, claim: Claim) -> Optional[WikidataQnode]:
-    """Create WikiData Qnodes from links."""
-    if len(link["options"]) < 1:
-        other_options = link["other_options"]
-        if len(other_options) > 1:
-            first_option = other_options[0]
-            text = first_option["rawName"][0] if first_option["rawName"] else None
-            qnode = first_option["qnode"][0] if first_option["qnode"] else None
-            description = first_option["definition"][0] if first_option["definition"] else None
-        else:
-            all_options = link["all_options"]
-            if len(all_options) < 1:
-                logging.warning("No WikiData links found for '%s'.", link["query"])
-                return None
-            else:
-                first_option = all_options[0]
-                text = first_option["label"][0] if first_option["label"] else None
-                qnode = first_option["qnode"] if first_option["qnode"] else None
-                description = (
-                    first_option["description"][0] if first_option["description"] else None
-                )
-    else:
-        text = link["options"][0]["rawName"]
-        qnode = link["options"][0]["qnode"]
-        description = link["options"][0]["definition"]
-
-    return WikidataQnode(
-        text=text,
-        mention_id=mention.mention_id,
-        doc_id=claim.doc_id,
-        span=mention.span,
-        qnode_id=qnode,
-        description=description,
-        from_query=link["query"],
-    )
 
 
 if __name__ == "__main__":

--- a/cdse_covid/semantic_extraction/utils/amr_extraction_utils.py
+++ b/cdse_covid/semantic_extraction/utils/amr_extraction_utils.py
@@ -12,7 +12,7 @@ from nltk.corpus import stopwords
 from cdse_covid.claim_detection.claim import Claim, create_id
 from cdse_covid.semantic_extraction.mentions import XVariable
 
-PROPBANK_PATTERN = r"[a-z]*-[0-9]{2}"  # e.g. have-name-91
+PROPBANK_PATTERN = r"[a-z, -]*-[0-9]{2}"  # e.g. have-name-91
 PRONOUNS = {
     "he",
     "she",

--- a/cdse_covid/semantic_extraction/utils/claimer_utils.py
+++ b/cdse_covid/semantic_extraction/utils/claimer_utils.py
@@ -122,7 +122,6 @@ def get_argument_node(
     nodes = amr.nodes
     nodes_to_strings = create_node_to_token_dict(amr, alignments)
     tokens_to_indices = create_tokens_to_indices(amr.tokens)
-    print(f"Tokens to indices for AMR graph: {tokens_to_indices}")
     amr_dict = amr.edge_mapping()
     node_args = amr_dict.get(claim_node)
     if node_args:

--- a/cdse_covid/semantic_extraction/utils/claimer_utils.py
+++ b/cdse_covid/semantic_extraction/utils/claimer_utils.py
@@ -11,6 +11,7 @@ from cdse_covid.claim_detection.claim import Claim, create_id
 from cdse_covid.semantic_extraction.mentions import Claimer
 from cdse_covid.semantic_extraction.utils.amr_extraction_utils import (
     create_node_to_token_dict,
+    create_tokens_to_indices,
     get_full_description,
     get_full_name_value,
     remove_preceding_trailing_stop_words,
@@ -120,6 +121,8 @@ def get_argument_node(
     """Get all argument (claimer) nodes of the claim node."""
     nodes = amr.nodes
     nodes_to_strings = create_node_to_token_dict(amr, alignments)
+    tokens_to_indices = create_tokens_to_indices(amr.tokens)
+    print(f"Tokens to indices for AMR graph: {tokens_to_indices}")
     amr_dict = amr.edge_mapping()
     node_args = amr_dict.get(claim_node)
     if node_args:
@@ -129,5 +132,7 @@ def get_argument_node(
             claimer_label = nodes.get(claimer_node)
             if claimer_label in ["person", "organization"]:
                 return get_full_name_value(amr_dict, nodes_to_strings, claimer_node)
-            return get_full_description(amr_dict, nodes, nodes_to_strings, claimer_node)
+            return get_full_description(
+                amr_dict, nodes, nodes_to_strings, tokens_to_indices, claimer_node
+            )
     return None


### PR DESCRIPTION
This PR makes a few changes that
* Provide cleaner claimer/x-variable strings
* Improve qnode selection

These changes include
* Returning the "best" qnode based on `linking_score` if choosing from `all_options` from a KGTK response
* Determining token order of claimer/x-variable through index
* Choosing the first option for the claimer if the one found has an "X and Y" pattern (e.g. "researchers" <-- "researchers and studies")
* Removing modifier tokens whose distance from the "focus" argument token is not aligned with that in the source text