### PR TITLE
Add pnode filter, use spacy tokenizer for calculating spans

### DIFF
--- a/cdse_covid/claim_detection/claim.py
+++ b/cdse_covid/claim_detection/claim.py
@@ -1,4 +1,5 @@
 """Claim module."""
+import string
 from dataclasses import dataclass, field
 import logging
 from typing import Any, Dict, List, MutableMapping, Optional, Tuple, Union
@@ -51,7 +52,7 @@ class Claim:
         """Get an existing theory by *name*."""
         return self.theories.get(name)
 
-    def get_offsets_for_text(self, text: Optional[str]) -> Optional[Tuple[int, int]]:
+    def get_offsets_for_text(self, text: Optional[str], tokenizer: Any) -> Optional[Tuple[int, int]]:
         """Get the character offsets of the given string based on its claim span."""
         if not text:
             return None
@@ -61,7 +62,8 @@ class Claim:
         if not tokens_to_offsets:
             logging.warning("No tokens -> offsets mapping for claim `%s`.", self.claim_sentence)
             return None
-        text_split = text.split(" ")
+        text_tokens = tokenizer(text.strip())
+        text_split = [token.text for token in text_tokens]
         first_token = text_split[0]
         last_token = text_split[-1]
         first_offsets = tokens_to_offsets.get(first_token)

--- a/cdse_covid/pegasus_pipeline/ingesters/edl_output_ingester.py
+++ b/cdse_covid/pegasus_pipeline/ingesters/edl_output_ingester.py
@@ -58,8 +58,9 @@ def main(edl_output: Path, output: Path) -> None:
                         ent_id=formatted_id, ent_type=ent_type, type_link=type_link
                     )
                 elif line[1] == "type":
-                    ent_type_uri = line[2]
                     # Type example: `https://tac.nist.gov/tracks/SM-KBP/2019/ontologies/LDCOntology#GPE.City`
+                    # Sometimes a number gets included, separated by whitespace
+                    ent_type_uri = line[2].split()[0]
                     ent_type = ent_type_uri.split("#")[-1]
                     new_entity = EDLEntity(ent_id=formatted_id, ent_type=ent_type)
 

--- a/cdse_covid/semantic_extraction/run_srl.py
+++ b/cdse_covid/semantic_extraction/run_srl.py
@@ -44,7 +44,7 @@ def main(inputs: Path, output: Path, *, spacy_model: Language) -> None:
                 label = arg_label_for_x_variable[0]  # Should only be one
                 x_variable = srl_out.args.get(label)
                 if x_variable:
-                    claim.x_variable = create_x_variable(x_variable, claim)
+                    claim.x_variable = create_x_variable(x_variable, claim, spacy_model.tokenizer)
 
         claim.add_theory("srl", srl_out)
     claim_ds.save_to_key_value_store(output)

--- a/cdse_covid/semantic_extraction/utils/claimer_utils.py
+++ b/cdse_covid/semantic_extraction/utils/claimer_utils.py
@@ -64,7 +64,7 @@ def identify_claimer(
                 mention_id=create_id(),
                 text=final_arg_node,
                 doc_id=claim.doc_id,
-                span=claim.get_offsets_for_text(final_arg_node),
+                span=claim.get_offsets_for_text(final_arg_node, spacy_model.tokenizer),
             )
     return None
 

--- a/wikidata_linker/get_claim_semantics.py
+++ b/wikidata_linker/get_claim_semantics.py
@@ -127,7 +127,7 @@ def get_best_qnode_for_mention_text(
     mention_span = None
     if isinstance(mention_or_text, str):
         mention_text = mention_or_text
-        mention_span = claim.get_offsets_for_text(mention_text)
+        mention_span = claim.get_offsets_for_text(mention_text, spacy_model.tokenizer)
     elif isinstance(mention_or_text, Mention):
         mention_text = mention_or_text.text
         mention_id = mention_or_text.mention_id

--- a/wikidata_linker/get_claim_semantics.py
+++ b/wikidata_linker/get_claim_semantics.py
@@ -22,6 +22,7 @@ from cdse_covid.semantic_extraction.utils.amr_extraction_utils import (
     PROPBANK_PATTERN,
     STOP_WORDS,
     create_node_to_token_dict,
+    remove_preceding_trailing_stop_words,
 )
 from wikidata_linker.linker import WikidataLinkingClassifier
 from wikidata_linker.wikidata_linking import CPU, disambiguate_refvar_kgtk, disambiguate_verb_kgtk
@@ -92,14 +93,13 @@ def get_all_labeled_args(
                 framenet_arg = get_framenet_arg_role(arg[1])
                 if qnode_args.get(framenet_arg):
                     node_label = amr.nodes[arg_node]
-                    token_of_node = node_labels_to_tokens.get(arg_node)
-                    if not token_of_node:
+                    tokens_of_node = node_labels_to_tokens.get(arg_node)
+                    if tokens_of_node:
+                        tokens_of_node = remove_preceding_trailing_stop_words(tokens_of_node)
+                    if not tokens_of_node:
                         labeled_args[framenet_arg] = node_label.rsplit("-", 1)[0]
-                    elif any(token_of_node.endswith(f" {stop_word}") for stop_word in STOP_WORDS):
-                        # Sometimes the extracted token or part of it is irrelevant
-                        labeled_args[framenet_arg] = token_of_node.rsplit(" ")[0]
                     else:
-                        labeled_args[framenet_arg] = token_of_node
+                        labeled_args[framenet_arg] = tokens_of_node
     return labeled_args
 
 

--- a/wikidata_linker/wikidata_linking.py
+++ b/wikidata_linker/wikidata_linking.py
@@ -165,12 +165,12 @@ def make_kgtk_candidates_filter(source_str: str) -> Callable[[Mapping[str, Any]]
     Returns:
         A filter function particular to source_str.
     """
-
     def kgtk_candidate_filter(candidate: Mapping[str, Any]) -> bool:
         str_found = source_str in candidate["label"][0]
         str_found = str_found or any(source_str in alias for alias in candidate["alias"])
         description_and_casematch = candidate["description"] and candidate["label"][0].islower()
-        return str_found and description_and_casematch
+        is_qnode = candidate["qnode"].startswith("Q")
+        return str_found and description_and_casematch and is_qnode
 
     return kgtk_candidate_filter
 


### PR DESCRIPTION
Addresses the following issues:
* "Pnode" (Wikidata property) selections instead of Qnodes; e.g. selecting `P2047` for "duration" instead of `Q2199864`
* Making it easier to find spans by using the spacy tokenizer on claims/sentences instead of simple splits
* Some type values in the CS file were followed by a number; left those out during ingestion
* Some arguments still had trailing/preceding stop words; applied a function to trim those

Before running the pipeline with these changes, remove the files from your `kgtk_event_cache` and `kgtk_refvar_cache`.